### PR TITLE
support labelled breakpoints

### DIFF
--- a/System/Breakpoint.hs
+++ b/System/Breakpoint.hs
@@ -11,16 +11,17 @@ module System.Breakpoint
     ) where
 
 import System.IO.Unsafe
+import Foreign.C.String
 import GHC.IO
 import GHC.Word
 import GHC.Int
 import GHC.Prim
 
-foreign import ccall unsafe "c_breakpoint" breakpoint :: IO ()
+foreign import ccall unsafe "c_breakpoint" breakpoint :: CString -> IO ()
 
-breakOnEval :: a -> a
-breakOnEval x = unsafePerformIO $ do
-    breakpoint
+breakOnEval :: String -> a -> a
+breakOnEval lbl x = unsafePerformIO . withCString lbl $ \clbl -> do
+    breakpoint clbl
     return x
 
 logPointer :: a -> IO ()

--- a/breakpoint-example.hs
+++ b/breakpoint-example.hs
@@ -1,0 +1,49 @@
+{-
+Build with 'cabal new-build', run with e.g:
+  gdb -q dist-newstyle/build/x86_64-linux/ghc-8.2.1/breakpoint-0.1.0.0/x/breakpoint-example/build/breakpoint-example/breakpoint-example
+
+Then in gdb type 'run' and you'll get to the breakpoints
+and have the label printed out as well!
+
+Program received signal SIGTRAP, Trace/breakpoint trap.
+c_breakpoint (label=0x4200107030 "0") at cbits/breakpoint.c:29
+29	  labelled(label);
+(gdb) c
+Continuing.
+
+Program received signal SIGTRAP, Trace/breakpoint trap.
+c_breakpoint (label=0x4200107070 "1") at cbits/breakpoint.c:29
+29	  labelled(label);
+(gdb)
+Continuing.
+
+Program received signal SIGTRAP, Trace/breakpoint trap.
+c_breakpoint (label=0x42001070b0 "2") at cbits/breakpoint.c:29
+29	  labelled(label);
+(gdb)
+Continuing.
+
+Program received signal SIGTRAP, Trace/breakpoint trap.
+c_breakpoint (label=0x42001070f0 "3") at cbits/breakpoint.c:29
+29	  labelled(label);
+(gdb)
+Continuing.
+
+Program received signal SIGTRAP, Trace/breakpoint trap.
+c_breakpoint (label=0x4200107130 "4") at cbits/breakpoint.c:29
+29	  labelled(label);
+(gdb)
+Continuing.
+
+Program received signal SIGTRAP, Trace/breakpoint trap.
+c_breakpoint (label=0x4200107170 "5") at cbits/breakpoint.c:29
+29	  labelled(label);
+(gdb)
+Continuing.
+[0,2,4,6,8,10]
+-}
+
+import System.Breakpoint
+
+main :: IO ()
+main = print $ map (\i -> breakOnEval (show i) (2*i)) [0..5]

--- a/breakpoint.cabal
+++ b/breakpoint.cabal
@@ -16,6 +16,14 @@ cabal-version:       >=1.10
 library
   exposed-modules:     System.Breakpoint
   c-sources:           cbits/breakpoint.c
+  cc-options:          -g -O0
+  ghc-options:         -g -O0
   other-extensions:    ForeignFunctionInterface
   build-depends:       base >=4.10 && <4.11, ghc-prim
   default-language:    Haskell2010
+
+executable breakpoint-example
+  default-language:    Haskell2010
+  build-depends:       base, ghc-prim, breakpoint
+  main-is:             breakpoint-example.hs
+  ghc-options:         -g -O0

--- a/cbits/breakpoint.c
+++ b/cbits/breakpoint.c
@@ -7,6 +7,8 @@ volatile uint64_t word_log[LOG_SIZE];
 volatile int log_idx = 0;
 volatile int lock = 0;
 
+volatile char* last_label = NULL;
+
 void c_log_word(uint64_t x) {
   while (__sync_lock_test_and_set(&lock, 1))
       while (lock);
@@ -15,8 +17,15 @@ void c_log_word(uint64_t x) {
   lock = 0;
 }
 
-void c_breakpoint() {
+void labelled(char* s) {
+  // silly non-noop thing to hopefully prevent 'labelled'
+  // from being optimized away
+  last_label = s;
+}
+
+void c_breakpoint(char* label) {
   __asm__("int $3");
+  labelled(label);
 }
 
 void c_log_tid() {


### PR DESCRIPTION
With this change, `gdb` now stops right before some silly, useless function call that takes the label as argument, and therefore prints the label (the `"0"` below):

``` c
Program received signal SIGTRAP, Trace/breakpoint trap.
c_breakpoint (label=0x4200107030 "0") at cbits/breakpoint.c:29
29	  labelled(label);
```